### PR TITLE
add cmake and build instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 2.8.10)
+project(zstd_hdf5)
+
+# options
+set(PLUGIN_INSTALL_PATH "/usr/local/hdf5/lib/plugin" CACHE PATH
+      "Where to install the dynamic HDF5-plugin")
+
+# sources
+set(SOURCES zstd_h5plugin.c)
+set(PLUGIN_SOURCES zstd_h5plugin.c)
+
+# dependencies
+if(MSVC)
+    # FindHDF5.cmake does not find Windows installations. Try to
+    # use an environment variable instead until the official "find"
+    # file can be updated for Windows.
+    #
+    # Note that you have to set this environment variable by hand.
+    file(TO_CMAKE_PATH "$ENV{HDF5_DIR}" HDF5_HINT)
+    set(HDF5_DIR ${HDF5_HINT} CACHE STRING "Path to HDF5 CMake config directory.")
+    find_package(HDF5 REQUIRED HINTS ${HDF5_DIR})
+else(MSVC)
+    find_package(HDF5 REQUIRED)
+endif(MSVC)
+include_directories(${HDF5_INCLUDE_DIRS})
+
+# HDF5 plugin as shared library
+add_library(zstd_h5_plugin_shared SHARED ${PLUGIN_SOURCES})
+set_target_properties(zstd_h5_plugin_shared PROPERTIES OUTPUT_NAME H5Zzstd)
+target_link_libraries(zstd_h5_plugin_shared zstd ${HDF5_LIBRARIES})
+install(TARGETS zstd_h5_plugin_shared DESTINATION ${PLUGIN_INSTALL_PATH} COMPONENT HDF5_FILTER_DEV)

--- a/README.md
+++ b/README.md
@@ -21,4 +21,16 @@ http://www.zstd.net
 ---
 
 This repository provides an implementation of Zstandard compression
-filter plugin for HDF5.
+filter plugin for HDF5 with the assigned filter code 32015.
+
+---
+
+## Build
+
+This plugin can be built with cmake and installed as shared library to `/usr/local/hdf5/lib/plugin` (or a custom path).
+
+```bash
+cmake .
+make
+sudo make install
+```

--- a/zstd_h5plugin.h
+++ b/zstd_h5plugin.h
@@ -1,6 +1,10 @@
 #include "hdf5.h"
 
-#define DLL_EXPORT __declspec(dllexport) 
+#if defined(_MSC_VER)
+    #define DLL_EXPORT __declspec(dllexport)
+#else
+    #define DLL_EXPORT
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This PR adds cmake as build tool and some build instructions to install the zstd-h5-plugin on Linux.