### PR TITLE
Added note about HDF5_PLUGIN_PATH in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,14 @@ filter plugin for HDF5 with the assigned filter code 32015.
 
 ## Build
 
-This plugin can be built with cmake and installed as shared library to `/usr/local/hdf5/lib/plugin` (or a custom path).
+This plugin can be built with cmake and installed as a shared library to
+`/usr/local/hdf5/lib/plugin` (or a custom path).
 
 ```bash
 cmake .
 make
 sudo make install
 ```
+
+At runtime, you can also specify where this plugin is located via the
+`HDF5_PLUGIN_PATH` environment variable.


### PR DESCRIPTION
In some cases, an h5py installtion will not be able to find the
correct path for the plugin. The use of the environment variable can
help the first-time user out a bit.